### PR TITLE
add apk dependencies required to build pip cryptography package 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,19 @@ MAINTAINER Dwolla Dev <dev+jenkins-python@dwolla.com>
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-python"
 
 USER root
-RUN apk add --update python py-pip python-dev jq make git zip && \
+RUN apk add --update \
+        python \
+        py-pip \
+        python-dev \
+        jq \ 
+        make \
+        git \
+        zip \
+        gcc \
+        musl-dev \
+        libffi-dev \
+        openssl-dev \
+        && \
     pip install --upgrade pip && \
     pip install awscli virtualenv && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
The Python cryptography package requires additional Linux system dependencies as documented here https://cryptography.io/en/latest/installation/#building-cryptography-on-linux.  

At Dwolla, this change will allow us to run two additional builds on Jenkins executors. 