### PR TITLE
Run global Pip updates on build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --update \
         python \
         python3 \
         py-pip \
+        py3-pip \
         python-dev \
         python3-dev \
         jq \ 
@@ -20,12 +21,15 @@ RUN apk add --update \
         openssl-dev \
         unixodbc-dev \
         && \
+    pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install --no-cache-dir -U \
+        && \
     pip install --upgrade \
         pip \
         setuptools \
-        virtualenv \
+        virtualenv && \
+    pip3 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install --no-cache-dir -U \
         && \
-    pip3 install --upgrade \
+    pip3 install --upgrade --no-cache-dir \
         pip \
         setuptools \
         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,18 @@ RUN apk add --update \
         openssl-dev \
         unixodbc-dev \
         && \
-    pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install --no-cache-dir -U \
-        && \
-    pip install --upgrade \
+    pip install --upgrade --no-cache-dir \
         pip \
         setuptools \
-        virtualenv && \
-    pip3 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install --no-cache-dir -U \
+        virtualenv \
+        && \
+    pip list --outdated --format=freeze | cut -d = -f 1  | xargs -r -n1 pip install --no-cache-dir -U \
         && \
     pip3 install --upgrade --no-cache-dir \
         pip \
         setuptools \
+        && \
+    pip3 list --outdated --format=freeze | cut -d = -f 1  | xargs -r -n1 pip3 install --no-cache-dir -U \
         && \
     rm -rf /var/cache/apk/* && \
     chown -R jenkins /usr/lib/python2.7/site-packages


### PR DESCRIPTION
Note that this still includes EOL (Jan 21) Python 2.7, which should be removed. But leaving that for a future PR