### PR TITLE
Remove Python 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,8 @@ LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-p
 
 USER root
 RUN apk add --update \
-        python \
         python3 \
-        py-pip \
         py3-pip \
-        python-dev \
         python3-dev \
         jq \ 
         make \
@@ -21,19 +18,12 @@ RUN apk add --update \
         openssl-dev \
         unixodbc-dev \
         && \
-    pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install --no-cache-dir -U \
-        && \
-    pip install --upgrade \
-        pip \
-        setuptools \
-        virtualenv && \
     pip3 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install --no-cache-dir -U \
         && \
     pip3 install --upgrade --no-cache-dir \
         pip \
         setuptools \
         && \
-    rm -rf /var/cache/apk/* && \
-    chown -R jenkins /usr/lib/python2.7/site-packages
+    rm -rf /var/cache/apk/*
 
 USER jenkins


### PR DESCRIPTION
Python 2 was EOL Jan 21 and is no longer receiving updates. This should no longer exist in our ecosystem.