### PR TITLE
Reusable workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @Dwolla/platform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,21 @@
 name: Build
 
 on:
-  pull_request:
-    branches: ['**']
   push:
     branches: ['**']
     tags: [v*]
 
-env:
-  core_tag: 4.13.2-1-jdk11-7b03219
-
 jobs:
   build:
+    uses: Dwolla/jenkins-agents-workflow/.github/workflows/build-docker-image.yml@main
+    with:
+      IMAGE_NAME: dwolla/jenkins-agent-python
+      TAG_NAME: CORE_TAG
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  build-complete:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Check Build
-        run: make check
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # https://github.com/docker/metadata-action
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            dwolla/jenkins-agent-python
-          # Docker tags based on the following events/attributes
-          tags: |
-            type=sha,prefix=${{ env.core_tag }}-
-
-      # https://github.com/docker/build-push-action
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: CORE_TAG=${{ env.core_tag }}
+      - run: echo "The build completed successfully"

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,16 @@
-CORE_TAG := 4.13.2-1-jdk11-7b03219
+CORE_TAG := $(CORE_JDK11_TAG)
 JOB := core-${CORE_TAG}
-CHECK_JOB := check-${CORE_TAG}
 CLEAN_JOB := clean-${CORE_TAG}
 
-all: ${CHECK_JOB} ${JOB}
-check: ${CHECK_JOB}
+all: ${JOB}
 clean: ${CLEAN_JOB}
-.PHONY: all check clean ${JOB} ${CHECK_JOB} ${CLEAN_JOB}
+.PHONY: all clean ${JOB} ${CLEAN_JOB}
 
 ${JOB}: core-%: Dockerfile
 	docker build \
 	  --build-arg CORE_TAG=$* \
 	  --tag dwolla/jenkins-agent-python:$*-SNAPSHOT \
 	  .
-
-${CHECK_JOB}: check-%:
-	grep --silent "^  core_tag: $*$$" .github/workflows/ci.yml
 
 ${CLEAN_JOB}: clean-%:
 	docker image rm --force dwolla/jenkins-agent-python:$*-SNAPSHOT

--- a/README.md
+++ b/README.md
@@ -7,4 +7,12 @@ Docker image based on [Dwolla’s core Jenkins Agent Docker image](https://githu
 
 GitHub Actions will build the Docker images for multiple supported architectures.
 
-To build locally, run `make all` or `make core-${TAG}` for one of the supported tags.
+## Local Development
+
+With [yq](https://kislyuk.github.io/yq/) installed, to build this image locally run the following command:
+
+`make CORE_JDK11_TAG=$(curl --silent https://raw.githubusercontent.com/Dwolla/jenkins-agents-workflow/main/.github/workflows/build-docker-image.yml | yq -r .on.workflow_call.inputs.CORE_TAG.default) all`
+
+Alternatively, without [yq](https://kislyuk.github.io/yq/) installed, refer to the CORE_TAG default value(s) defined in [jenkins-agents-workflow](https://github.com/Dwolla/jenkins-agents-workflow/blob/main/.github/workflows/build-docker-image.yml) and run the following command:
+
+`make CORE_JDK11_TAG=<default-core-tag-from-jenkins-agents-workflow> all`


### PR DESCRIPTION
This must have been initally missed when we updated all jenkins-agent-* repos to point to the reusable workflow.

Update workflow to utilize `jenkins-agents-workflow`.