### PR TITLE
install pyenv global version as jenkins user instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN curl https://pyenv.run | bash && \
 
 RUN chown -R jenkins:jenkins "${JENKINS_HOME}/.pyenv"
 
+USER jenkins
+
 RUN pyenv install 3.9
 
 RUN pyenv global 3.9
-
-USER jenkins


### PR DESCRIPTION
`pyenv install` commands are currently not working when running as `jenkins` on the container bc the version/s folder is owned by root:
```
sh-5.1$ ls -lart /home/jenkins/.pyenv
total 316
...
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 16:49 pyenv.d
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 16:49 .git
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 16:49 plugins
drwxr-xr-x 3 root    root      4096 Mar 12 17:07 versions
-rw-r--r-- 1 root    root         4 Mar 12 17:11 version
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 17:11 .
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 20:34 shims
drwxr-xr-x 1 jenkins jenkins   4096 Mar 12 20:35 ..
```